### PR TITLE
keep compatible with latest sysbench

### DIFF
--- a/sysbench/cleanup.sh
+++ b/sysbench/cleanup.sh
@@ -2,10 +2,10 @@
 
 set -x
 
-source ./conf.sh
+. ./conf.sh
 
 
-sysbench --test=./lua-tests/db/oltp.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/oltp.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
   --mysql-user=${user} --mysql-password=${password} --mysql-db=${dbname} \
   --oltp-tables-count=${tcount} cleanup
 

--- a/sysbench/conf.sh
+++ b/sysbench/conf.sh
@@ -9,10 +9,12 @@ threads=256
 dbname=sbtest1
 
 # report interval
-interval=60
+interval=10
 
 # max time in seconds
 maxtime=600
 
 # just large enough to fit maxtime
 requests=2000000000
+
+driver=mysql

--- a/sysbench/delete.sh
+++ b/sysbench/delete.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-source ./conf.sh
+. ./conf.sh
 
-sysbench --test=./lua-tests/db/delete.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/delete.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
  --mysql-user=${user} --mysql-password=${password} --mysql-db=${dbname} \
  --oltp-tables-count=${tcount} --oltp-table-size=${tsize} \
  --num-threads=${threads} --report-interval=${interval} \

--- a/sysbench/insert.sh
+++ b/sysbench/insert.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-source ./conf.sh
+. ./conf.sh
 
-sysbench --test=./lua-tests/db/insert.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/insert.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
  --mysql-user=${user} --mysql-password=${password} --mysql-db=${dbname} \
  --oltp-tables-count=${tcount} --oltp-table-size=${tsize} \
  --num-threads=${threads} --report-interval=${interval} \

--- a/sysbench/lua-tests/db/common.lua
+++ b/sysbench/lua-tests/db/common.lua
@@ -122,16 +122,16 @@ function cleanup()
 end
 
 function set_vars()
-   oltp_table_size = oltp_table_size or 10000
-   oltp_range_size = oltp_range_size or 100
-   oltp_tables_count = oltp_tables_count or 1
-   oltp_point_selects = oltp_point_selects or 10
-   oltp_simple_ranges = oltp_simple_ranges or 1
-   oltp_sum_ranges = oltp_sum_ranges or 1
-   oltp_order_ranges = oltp_order_ranges or 1
-   oltp_distinct_ranges = oltp_distinct_ranges or 1
-   oltp_index_updates = oltp_index_updates or 1
-   oltp_non_index_updates = oltp_non_index_updates or 1
+   oltp_table_size = tonumber(oltp_table_size or 10000)
+   oltp_range_size = tonumber(oltp_range_size or 100)
+   oltp_tables_count = tonumber(oltp_tables_count or 1)
+   oltp_point_selects = tonumber(oltp_point_selects or 10)
+   oltp_simple_ranges = tonumber(oltp_simple_ranges or 1)
+   oltp_sum_ranges = tonumber(oltp_sum_ranges or 1)
+   oltp_order_ranges = tonumber(oltp_order_ranges or 1)
+   oltp_distinct_ranges = tonumber(oltp_distinct_ranges or 1)
+   oltp_index_updates = tonumber(oltp_index_updates or 1)
+   oltp_non_index_updates = tonumber(oltp_non_index_updates or 1)
 
    if (oltp_auto_inc == 'off') then
       oltp_auto_inc = false

--- a/sysbench/oltp.sh
+++ b/sysbench/oltp.sh
@@ -2,10 +2,10 @@
 
 set -x
 
-source ./conf.sh
+. ./conf.sh
 
 # run
-sysbench --test=./lua-tests/db/oltp.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/oltp.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
   --mysql-user=${user} --mysql-password=${password} --mysql-db=${dbname} \
   --oltp-tables-count=${tcount} --oltp-table-size=${tsize} \
   --num-threads=${threads} --max-requests=${requests} \

--- a/sysbench/parallel-prepare.sh
+++ b/sysbench/parallel-prepare.sh
@@ -2,15 +2,15 @@
 
 set -x
 
-source ./conf.sh
+. ./conf.sh
 
-sysbench --test=./lua-tests/db/oltp.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/oltp.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
  --mysql-user=${user} --mysql-password=${password} --oltp-tables-count=${tcount} --mysql-db=${dbname} \
  --oltp-table-size=0 --rand-init=on prepare
 
 sleep 5
 
-sysbench --test=./lua-tests/db/parallel_prepare.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/parallel_prepare.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
  --mysql-user=${user} --mysql-password=${password} --oltp-tables-count=${tcount} --mysql-db=${dbname} \
  --oltp-table-size=${tsize} --num-threads=${threads}  --rand-init=on run
 

--- a/sysbench/prepare.sh
+++ b/sysbench/prepare.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-source ./conf.sh
+. ./conf.sh
 
-sysbench --test=./lua-tests/db/oltp.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/oltp.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
  --mysql-user=${user} --mysql-password=${password} --mysql-db=${dbname} \
  --oltp-tables-count=${tcount} --oltp-table-size=${tsize} --rand-init=on prepare
 

--- a/sysbench/select.sh
+++ b/sysbench/select.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-source ./conf.sh
+. ./conf.sh
 
-sysbench --test=./lua-tests/db/select.lua --mysql-host=${host} --mysql-port=${port} \
+sysbench --test=./lua-tests/db/select.lua --db-driver=${driver} --mysql-host=${host} --mysql-port=${port} \
  --mysql-user=${user} --mysql-password=${password} --mysql-db=${dbname} \
  --oltp-tables-count=${tcount} --oltp-table-size=${tsize} \
  --num-threads=${threads} --report-interval=${interval} \


### PR DESCRIPTION
- source command is not supported in all shell
- db driver should be specified explicitly
- string should be convert to number explicitly
