### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 TiDB standard test suite.
 
 ## Supports
-
-- sysbench
+tidb-bench has been tested against below version of sysbench/luajit:
+- sysbench 1.0.6 (using system LuaJIT 2.0.4)


### PR DESCRIPTION
it has been found that tidb-bench is not compatible with LuaJIT 2.1.0-beta2.