### PR TITLE
add a Docker image with benchmarking utilities

### DIFF
--- a/docker/tidb-bench/Dockerfile
+++ b/docker/tidb-bench/Dockerfile
@@ -1,0 +1,41 @@
+FROM golang:1.12.1-alpine3.9 AS goycsb
+
+RUN apk add git build-base \
+  && git clone https://github.com/pingcap/go-ycsb $GOPATH/src/github.com/pingcap/go-ycsb \
+  && cd $GOPATH/src/github.com/pingcap/go-ycsb \
+  && make
+
+FROM alpine:3.9
+MAINTAINER PingCAP <cloud@pingcap.com>
+
+# Install sysbench
+# gcc and mariadb-dev install shared libraries
+RUN apk add gcc mariadb-dev \
+  && apk add --virtual .build-deps git build-base automake autoconf libtool --update \
+  && git clone https://github.com/akopytov/sysbench.git \
+  && cd sysbench \
+  && ./autogen.sh \
+  && ./configure --disable-shared \
+  && make \
+  && make install \
+  && cd .. \
+  && rm -r sysbench \
+  && apk del .build-deps
+
+# TiDB patch for sysbench data loading (prepare)
+RUN apk add --virtual .build-deps wget \
+  && wget https://raw.githubusercontent.com/pingcap/tidb-bench/master/sysbench-patch/oltp_common.lua \
+  && apk del .build-deps \
+  && mv oltp_common.lua /usr/local/share/sysbench/oltp_common.lua
+
+RUN apk add mysql-client
+RUN apk add bash
+COPY --from=dmonakhov/alpine-fio /usr/local/bin/fio /usr/local/bin/fio
+
+COPY --from=goycsb /go/src/github.com/pingcap/go-ycsb/bin/go-ycsb /go-ycsb/bin/go-ycsb
+COPY --from=goycsb /go/src/github.com/pingcap/go-ycsb/workloads /go-ycsb/workloads
+COPY --from=goycsb /go/src/github.com/pingcap/go-ycsb/tool /go-ycsb/tool
+
+ADD README.md /README.md
+
+CMD ["bash"]

--- a/docker/tidb-bench/README.md
+++ b/docker/tidb-bench/README.md
@@ -1,0 +1,54 @@
+This image includes various utilities used to benchmark TiDB.
+
+# Performance tests
+
+* sysbench
+* go-ycsb
+
+
+# Disk tests
+
+*Note:* All the commands need to be run under the disk mount point. And the test.data file need to be deleted before test.
+
+## fio
+* Read
+```
+fio -ioengine=libaio -bs=32k -direct=1 -thread -rw=read -size=10G -filename=test.data -name="PingCAP max throughput" -iodepth=4 -runtime=60
+```
+
+* Write
+```
+fio -ioengine=libaio -bs=32k -direct=1 -thread -rw=write -size=10G -filename=test.data -name="PingCAP max throughput" -iodepth=4 -runtime=60
+```
+
+* Random read
+```
+fio -ioengine=libaio -bs=32k -direct=1 -thread -rw=randread -size=10G -filename=test.data -name="PingCAP max throughput" -iodepth=4 -runtime=60
+```
+
+* Random write
+```
+fio -ioengine=libaio -bs=32k -direct=1 -thread -rw=randwrite  -size=10G -filename=test.data -name="PingCAP max throughput" -iodepth=4 -runtime=60
+```
+
+* Random read & write
+```
+fio -ioengine=libaio -bs=32k -direct=1 -thread -rw=randrw -percentage_random=100,0 -size=10G -filename=test.data -name="PingCAP max throughput" -iodepth=4 -runtime=60
+```
+
+## dd
+
+* Cache write
+```
+dd bs=4k count=400000 if=/dev/zero of=test.data
+```
+
+* Direct write
+```
+dd bs=4k count=400000 if=/dev/zero of=test.data oflag=direct
+```
+
+* Direct read
+```
+dd bs=4k count=400000 if=test.data of=/dev/null& oflag=direct
+```

--- a/docker/tidb-bench/build.sh
+++ b/docker/tidb-bench/build.sh
@@ -1,0 +1,1 @@
+docker build -t pingcap/tidb-bench .


### PR DESCRIPTION
I haven't had a chance to fully test this yet.

Currently it just uses the sysbench patch in this repo, but it would also make sent to build the rest of the directories that are in this repo.